### PR TITLE
lock Dockerfile to Python 3.10.9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-FROM python:slim
+FROM python:3.10.9-slim
 
 RUN apt update && apt -y install libsndfile1 ffmpeg redis-server supervisor
 


### PR DESCRIPTION
Attempting to use `python:slim` (i.e. 3.11.1 currently) to build the image throws an error:

`Cannot install on Python version 3.11.1; only versions >=3.7,<3.11 are supported.`

```
#9 17.29 Collecting numba>=0.53
#9 17.33   Downloading numba-0.56.4.tar.gz (2.4 MB)
#9 17.50      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 2.4/2.4 MB 14.6 MB/s eta 0:00:00
#9 17.78   Preparing metadata (setup.py): started
#9 18.22   Preparing metadata (setup.py): finished with status 'error'
#9 18.23   error: subprocess-exited-with-error
#9 18.23
#9 18.23   × python setup.py egg_info did not run successfully.
#9 18.23   │ exit code: 1
#9 18.23   ╰─> [8 lines of output]
#9 18.23       Traceback (most recent call last):
#9 18.23         File "<string>", line 2, in <module>
#9 18.23         File "<pip-setuptools-caller>", line 34, in <module>
#9 18.23         File "/tmp/pip-install-ju2_a2v6/numba_737a6a5fa976445da5b5a7dfabfad88c/setup.py", line 51, in <module>
#9 18.23           _guard_py_ver()
#9 18.23         File "/tmp/pip-install-ju2_a2v6/numba_737a6a5fa976445da5b5a7dfabfad88c/setup.py", line 48, in _guard_py_ver
#9 18.23           raise RuntimeError(msg.format(cur_py, min_py, max_py))
#9 18.23       RuntimeError: Cannot install on Python version 3.11.1; only versions >=3.7,<3.11 are supported.
#9 18.23       [end of output]

...
```